### PR TITLE
Adding functionality for subscribing PlotlyChart event handling

### DIFF
--- a/Plotly.Blazor/PlotlyChart.razor
+++ b/Plotly.Blazor/PlotlyChart.razor
@@ -510,13 +510,13 @@
                 var xData = currentXData as object[] ?? currentXData.ToArray();
 
                 var list = (IList<object>)traceType.GetProperty("X")?.GetValue(currentTrace);
-               
+
                 if (xData.Length > 0)
                 {
                     list.InsertRange(0, xData);
 
                 }
-                
+
                 if (max != null)
                 {
                     traceType.GetProperty("X")?.SetValue(currentTrace, list?.Take(max.Value).ToList());
@@ -530,12 +530,12 @@
                 var yData = currentYData as object[] ?? currentYData.ToArray();
 
                 var list = (IList<object>)traceType.GetProperty("Y")?.GetValue(currentTrace);
-               
+
                 if (yData.Length > 0)
                 {
                     list.InsertRange(0, yData);
                 }
-                
+
                 if (max != null)
                 {
                     traceType.GetProperty("Y")?.SetValue(currentTrace, list?.Take(max.Value).ToList());
@@ -582,5 +582,29 @@
     public void Dispose()
     {
         objectReference?.Dispose();
+    }
+
+    /// <summary>
+    /// Defines the action that should happen when the ClickEvent is triggered.
+    /// Objects are currently required for accomodating different plot value types
+    /// </summary>
+    [Parameter]
+    public Action<object, object> ClickAction { get; set; }
+
+    /// <summary>
+    /// Method which is called by JSRuntime once a plot has been clicked, to invoke the passed in Action
+    /// Objects are currently required for accomodating different plot value types
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    [JSInvokable("ClickEvent")]
+    public void ClickEvent(object x, object y)
+    {
+        ClickAction?.Invoke(x, y);
+    }
+
+    public async Task SubscribeClickEvent()
+    {
+        await JsRuntime.SubscribeClickEvent(objectReference);
     }
 }

--- a/Plotly.Blazor/PlotlyJsInterop.cs
+++ b/Plotly.Blazor/PlotlyJsInterop.cs
@@ -152,7 +152,15 @@ namespace Plotly.Blazor
         }
 
 
-
-
+        /// <summary>
+        ///  Can be used to subscribe click events for Plot points.
+        /// </summary>
+        /// <param name="jsRuntime"></param>
+        /// <param name="objectReference"></param>
+        /// <returns></returns>
+        public static async Task SubscribeClickEvent(this IJSRuntime jsRuntime, DotNetObjectReference<PlotlyChart> objectReference)
+        {
+            await jsRuntime.InvokeVoidAsync($"{PlotlyInterop}.subscribeClickEvent", objectReference, objectReference.Value.Id);
+        }
     }
 }

--- a/Plotly.Blazor/wwwroot/plotly-interop.js
+++ b/Plotly.Blazor/wwwroot/plotly-interop.js
@@ -52,5 +52,11 @@
     },
     restyle: function (id, data, indizes) {
         window.Plotly.restyle(id, data, indizes);
+    },
+    subscribeClickEvent: function (dotNetObj, id) {
+        var plot = document.getElementById(id);
+        plot.on('plotly_click', function (data) {
+            dotNetObj.invokeMethodAsync('ClickEvent', data.points[0].x, data.points[0].y);
+        })
     }
 }


### PR DESCRIPTION
Based on the suggestion provided in #27.

Main change here is that we have accepted objects as xy parameters so other types and complex objects used on axes work.